### PR TITLE
Make sure destination doesn't resolve to /

### DIFF
--- a/use.sh
+++ b/use.sh
@@ -32,6 +32,11 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     uri="${artifact_pair/=*}"
     destination="${artifact_pair/*=}"
 
+    if [ "$(realpath "${destination}")" == "/" ]; then
+      echo Not a valid destination: "${destination}", resolves to /
+      exit 1
+    fi
+
     type="${uri/:*}"
 
     if [ "${type}" != "file" ]; then


### PR DESCRIPTION
Since the files at the destination path will be deleted we don't want to allow the destination to point to /.