### PR TITLE
Don't remove the destination directory

### DIFF
--- a/use.sh
+++ b/use.sh
@@ -61,8 +61,11 @@ for artifact_pair in "${artifact_pairs[@]}"; do
 
     echo "${digest} ${archive}" | "${digest_algorithm}sum" --check --quiet --strict
 
-    if [ -e "${destination}" ]; then
-        rm -rf "${destination}"
+    if [ -d "${destination}" ]; then
+        (
+            shopt -s dotglob
+            rm -rf "${destination:?}"/*
+        )
     fi
 
     mkdir -p "${destination}"


### PR DESCRIPTION
If the destination directory exists we do not want to remove it. This allows setting the `workingDir` to a directory that could have been created on the persistent volume in the previous step/task. With this the content of the directory will be removed but the directory would remain.