### PR TITLE
Use named results instead of ARTIFACTS array

### DIFF
--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -98,9 +98,8 @@ spec:
           value: ${repository}/golden
         - name: DOCKERFILE
           value: Containerfile
-        - name: ARTIFACTSS
-          value:
-            - \$(tasks.clone.results.ARTIFACTS[0])=\$(workspaces.source.path)/source
+        - name: SOURCE_ARTIFACT
+          value: \$(tasks.clone.results.SOURCE_ARTIFACT)=\$(workspaces.source.path)/source
       taskRef:
         name: buildah
       workspaces:

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -15,8 +15,8 @@ patches:
       - op: add
         path: /spec/results/-
         value:
-          name: ARTIFACTS
-          type: array
+          name: SOURCE_ARTIFACT
+          type: string
           description: Produced trusted artifact
       - op: add
         path: /spec/steps/-
@@ -25,7 +25,7 @@ patches:
           image: ${repository}/build-trusted-artifacts
           args:
             - create
-            - $(context.taskRun.name)=$(workspaces.output.path)/$(params.subdirectory)
+            - $(results.SOURCE_ARTIFACT.path)=$(workspaces.output.path)/$(params.subdirectory)
   - target:
       kind: Task
       name: buildah
@@ -34,8 +34,8 @@ patches:
       - op: add
         path: /spec/params/-
         value:
-          name: ARTIFACTSS
-          type: array
+          name: SOURCE_ARTIFACT
+          type: string
       - op: add
         path: /spec/steps/0
         value:
@@ -43,4 +43,4 @@ patches:
           image: ${repository}/build-trusted-artifacts
           args:
             - use
-            - $(params.ARTIFACTSS[*])
+            - $(params.SOURCE_ARTIFACT)

--- a/use.sh
+++ b/use.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 supported_digest_algorithms=(sha256 sha384 sha512)
 
-
 # contains name=path artifact pairs
 artifact_pairs=()
 
@@ -44,8 +43,9 @@ for artifact_pair in "${artifact_pairs[@]}"; do
         exit 1
     fi
 
+
     name="${uri#*:}"
-    name="${name/@*}"
+    name="${name/:*}"
 
     archive="${store}/${name}".tar.gz
 
@@ -54,15 +54,15 @@ for artifact_pair in "${artifact_pairs[@]}"; do
         exit 1
     fi
 
-    digest_algorithm=${uri#*@}
-    digest_algorithm=${digest_algorithm%:*}
+    digest_algorithm=${uri/-*}
+    digest_algorithm=${digest_algorithm/*:}
     supported=0
     case "${supported_digest_algorithms[@]}" in *"${digest_algorithm}"*) supported=1 ;; esac
     if [ $supported -eq 0 ]; then
         echo "Unsupported digest algorthm: ${digest_algorithm}"
         exit 1
     fi
-    digest="${uri/*:}"
+    digest="${uri/*-}"
 
     echo "${digest} ${archive}" | "${digest_algorithm}sum" --check --quiet --strict
 
@@ -77,5 +77,5 @@ for artifact_pair in "${artifact_pairs[@]}"; do
 
     tar -xpf "${archive}" -C "${destination}"
 
-    echo Restored artifact "${name}" to "${destination} (${digest_algorithm}:${digest})"
+    echo Restored artifact to "${destination} (${digest_algorithm}:${digest})"
 done


### PR DESCRIPTION
Makes the use of results much nicer as the specific named results can be used instead of indexes within the ARTIFACTS array. We do loose the name of the TaskRun from the context for the sake of simplicity, so that another parameter is not introduced to carry the name over to the scripts.