### PR TITLE
Don't create the temp archive within the store

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -34,7 +34,7 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     result_path="${artifact_pair/=*}"
     dir="${artifact_pair/*=}"
 
-    archive="$(mktemp -p "${store}").tar.gz"
+    archive="$(mktemp).tar.gz"
 
     if [ -d "${dir}" ]; then
         # archive the whole directory


### PR DESCRIPTION
Creating the temp archive within the store allows for a race condition when the store resides on a shared, writable by many, volume. This reverts to using the default `TEMP` directory instead.