### PR TITLE
Non-existent paths should create empty archives

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+const emptyFilePath = "sha256-85cea451eec057fa7e734548ca3ba6d779ed5836a3f9de14b8394575ef0d7d8e.tar.gz"
+
 func TestFeatures(t *testing.T) {
 	suite := godog.TestSuite{
 		ScenarioInitializer:  initializeScenario,
@@ -36,6 +38,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^artifact is created for file "([^"]*)"$`, createArtifactForFile)
 	sc.Step(`^artifact is extracted for file "([^"]*)"$`, useArtifactForFile)
 	sc.Step(`^the restored file "([^"]*)" should match its source$`, restoredFileShouldMatchSource)
+	sc.Step(`^the created archive is empty$`, createdArchiveIsEmpty)
 }
 
 func initializeTestSuite(suite *godog.TestSuiteContext) {
@@ -173,6 +176,19 @@ func restoredFileShouldMatchSource(ctx context.Context, fname string) (context.C
 	if !cmp.Equal(sourceContent, restoredContent) {
 		return ctx, fmt.Errorf("source file does not match restored file: \n%s",
 			cmp.Diff(sourceContent, restoredContent, toStringList))
+	}
+
+	return ctx, nil
+}
+
+func createdArchiveIsEmpty(ctx context.Context) (context.Context, error) {
+	ts, err := getTestState(ctx)
+	if err != nil {
+		return ctx, fmt.Errorf("no test state: %w", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(ts.artifactsDir(), emptyFilePath)); err != nil {
+		return ctx, fmt.Errorf("the empty archive is not present: %v", err)
 	}
 
 	return ctx, nil

--- a/acceptance/features/artifacts.feature
+++ b/acceptance/features/artifacts.feature
@@ -10,3 +10,7 @@ Feature: Artifacts
         When artifact is created for file "foobar.json"
         And artifact is extracted for file "foobar.json"
         Then the restored file "foobar.json" should match its source
+
+    Scenario: Non-existant paths create empty archives
+        When artifact is created for file "nonexistant"
+        Then the created archive is empty

--- a/create.sh
+++ b/create.sh
@@ -32,16 +32,19 @@ done
 
 for artifact_pair in "${artifact_pairs[@]}"; do
     result_path="${artifact_pair/=*}"
-    dir="${artifact_pair/*=}"
+    path="${artifact_pair/*=}"
 
     archive="$(mktemp).tar.gz"
 
-    if [ -d "${dir}" ]; then
-        # archive the whole directory
-        tar -czf "${archive}" -C "${dir}" .
+    if [ ! -r "${path}" ]; then
+        # non-existent paths result in empty archives
+        tar -czf "${archive}" --files-from /dev/null
+    elif [ -d "${path}" ]; then
+        # archive the whole pathectory
+        tar -czf "${archive}" -C "${path}" .
     else
         # archive a single file
-        tar -czf "${archive}" -C "${dir%/*}" "${dir##*/}"
+        tar -czf "${archive}" -C "${path%/*}" "${path##*/}"
     fi
 
     sha256sum_output="$(sha256sum "${archive}")"
@@ -50,5 +53,5 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     mv "${archive}" "${artifact}"
     echo -n "file:sha256-${digest}" > "${result_path}"
 
-    echo Created artifact from "${dir} (sha256:${digest})"
+    echo Created artifact from "${path} (sha256:${digest})"
 done


### PR DESCRIPTION
This allows tasks not to produce any files/directories.