### PR TITLE
[do not merge] Preserve permissions when creating the OCI artifact to store

### DIFF
--- a/create-oci.sh
+++ b/create-oci.sh
@@ -21,7 +21,7 @@ set -o pipefail
 
 # using `-n` ensures gzip does not add a modification time to the output. This
 # helps in ensuring the archive digest is the same for the same content.
-tar_opts=(--create --use-compress-program='gzip -n' --file)
+tar_opts=(--create --preserve-permissions --use-compress-program='gzip -n' --file)
 if [[ -v DEBUG ]]; then
   tar_opts=(--verbose "${tar_opts[@]}")
   set -o xtrace


### PR DESCRIPTION
When changing from a pipeline that is PVC backed to a trusted artifact one, builds need to be run with USER 0 if modifying the source. We should ensure to preserve permissions when creating the tarball.