### PR TITLE
Reduce memory usage during artifact extraction

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,11 @@ ARG TARGETARCH
 ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz /tmp
 RUN microdnf install --assumeyes tar gzip && tar -x -C /tmp -f /tmp/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz
 
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as drop-cache
+COPY drop_cache.c /tmp/drop_cache.c
+RUN microdnf install --assumeyes gcc && \
+    gcc -shared -fPIC -o /tmp/drop_cache.so /tmp/drop_cache.c -ldl
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
@@ -29,6 +34,7 @@ LABEL \
 
 COPY --from=files / /
 COPY --chown=0:0 --from=oras /tmp/oras /usr/local/bin/oras
+COPY --from=drop-cache /tmp/drop_cache.so /usr/local/lib/drop_cache.so
 COPY --from=buildah-task-image /usr/bin/retry /usr/local/bin/
 
 RUN microdnf update --assumeyes --nodocs --setopt=keepcache=0 && \

--- a/drop_cache.c
+++ b/drop_cache.c
@@ -1,0 +1,12 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <stddef.h>
+
+int close(int fd) {
+    static int (*real_close)(int) = NULL;
+    if (!real_close)
+        real_close = dlsym(RTLD_NEXT, "close");
+    posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    return real_close(fd);
+}

--- a/use-oci.sh
+++ b/use-oci.sh
@@ -80,7 +80,7 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     select-oci-auth.sh "$name" > "$authfile"
 
     retry oras blob fetch "${oras_opts[@]}" --registry-config "$authfile" \
-        "${name}" --output - | tar -C "${destination}" "${tar_opts}" -
+        "${name}" --output - | LD_PRELOAD=/usr/local/lib/drop_cache.so tar -C "${destination}" "${tar_opts}" -
 
     echo "Restored artifact ${name} to ${destination}"
 done


### PR DESCRIPTION
When extracting large archives in OpenShift, the Linux kernel's page cache accumulates written file data and counts it against the container's cgroup memory limit. For large artifacts (e.g. 4+ GB), this can push the container past its memory limit and trigger an OOM kill, even though the tar process itself only uses ~50 MB of heap memory.

This adds an LD_PRELOAD shim that intercepts close() and calls posix_fadvise(FADV_DONTNEED) on the file descriptor before closing it. This tells the kernel to evict the file's pages from cache immediately. When applied to tar during extraction, each file's pages are released as soon as tar finishes writing it, keeping memory usage flat regardless of archive size.