### PR TITLE
feat: throttle artifact extraction to reduce memory pressure from pag…

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,6 +35,10 @@ RUN microdnf update --assumeyes --nodocs --setopt=keepcache=0 && \
     microdnf install --assumeyes --nodocs --setopt=keepcache=0 tar gzip time jq findutils && \
     useradd --non-unique --uid 0 --gid 0 --shell /bin/bash notroot
 
+# TODO: Obviously, don't do this...
+ADD https://www.ivarch.com/programs/binaries/pv-1.10.5-1.el9.x86_64.rpm /tmp
+RUN rpm -ivh /tmp/pv-1.10.5-1.el9.x86_64.rpm && pv --version && rm /tmp/pv-1.10.5-1.el9.x86_64.rpm
+
 RUN oras version
 
 USER notroot

--- a/use-oci.sh
+++ b/use-oci.sh
@@ -80,7 +80,7 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     select-oci-auth.sh "$name" > "$authfile"
 
     retry oras blob fetch "${oras_opts[@]}" --registry-config "$authfile" \
-        "${name}" --output - | tar -C "${destination}" "${tar_opts}" -
+        "${name}" --output - | pv --rate-limit "${PV_RATE_LIMIT:-1G}" -q | tar -C "${destination}" "${tar_opts}" -
 
     echo "Restored artifact ${name} to ${destination}"
 done


### PR DESCRIPTION
…e cache

When oras pipes data to tar, tar writes to page cache at near-memory speed while the kernel flushes dirty pages to disk asynchronously. If the network is faster than the disk, dirty pages accumulate and cause memory pressure.

Insert pv between oras and tar to rate-limit the data flow. This introduces backpressure through the pipe so oras does not get too far ahead of the disk's write capacity. The rate defaults to 1G/s and can be tuned via the PV_RATE_LIMIT environment variable.