### PR TITLE
fix(RELEASE-2158): append custom CA to system bundle

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,8 @@ RUN microdnf update --assumeyes --nodocs --setopt=keepcache=0 && \
 
 RUN oras version
 
+RUN chmod -R a+w /etc/pki/
+
 USER notroot
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]

--- a/oras_opts.sh
+++ b/oras_opts.sh
@@ -2,19 +2,21 @@
 
 oras_opts=(${ORAS_OPTIONS:-})
 
-# Only set --ca-file if CA_FILE is non-empty AND file exists and is not empty
-# This avoids overriding system trust store and prevents "file not found" errors
 if [[ -v CA_FILE && -n "$CA_FILE" ]]; then
-    if [[ -f "$CA_FILE" && -s "$CA_FILE" ]]; then
-        oras_opts+=(--ca-file=${CA_FILE})
-        echo "Using custom CA certificate: $CA_FILE" >&2
-    elif [[ -f "$CA_FILE" ]]; then
-        echo "Warning: CA certificate file is empty: $CA_FILE" >&2
-        echo "Falling back to system trust store" >&2
+  if [[ -f "$CA_FILE" && -s "$CA_FILE" ]]; then
+    system_bundle=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+    if [ -w "$system_bundle" ]; then
+      cat "$CA_FILE" >> "$system_bundle"
+      echo "Appended custom CA to system trust bundle" >&2
     else
-        echo "Warning: CA certificate path provided but file not found: $CA_FILE" >&2
-        echo "Falling back to system trust store" >&2
+      oras_opts+=(--ca-file=${CA_FILE})
+      echo "Using custom CA certificate (fallback): $CA_FILE" >&2
     fi
+  elif [[ -f "$CA_FILE" ]]; then
+    echo "Warning: CA certificate file is empty: $CA_FILE" >&2
+  else
+    echo "Warning: CA certificate path provided but file not found: $CA_FILE" >&2
+  fi
 fi
 
 if [[ ! -z "${DEBUG:-}" ]]; then


### PR DESCRIPTION
Replace the oras --ca-file approach with appending the custom CA to the system trust bundle. Using --ca-file replaces the entire trust store, which breaks connections to public registries (e.g. quay.io) when ociStorage points there but a custom CA ConfigMap is also present.

Containerfile: grant group write permission to /etc/pki/ before USER so the runtime user (overridden to 1001 by securityContext) can write to the system bundle.

Assisted-by: Cursor