### PR TITLE
chore: enable platformAutomerge in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,6 @@
   "schedule": [
     "before 10am on Tuesday"
   ],
-  "automerge": true
+  "automerge": true,
+  "platformAutomerge": true
 }


### PR DESCRIPTION
- Enable `platformAutomerge: true` so Renovate uses GitHub's native auto-merge API
- Dependency PRs will now merge as soon as required status checks pass, instead of waiting for the next Renovate schedule window ("before 10am on Tuesday")
- This fixes the issue where only ~1 dependency PR auto-merged per week, causing the rest to accumulate

Requires repo-level auto-merge to be enabled and required status checks to be configured on `main` (both done).
