### PR TITLE
fix: detect Containerfile build errors in acceptance tests

### DIFF
--- a/acceptance/container.go
+++ b/acceptance/container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/go-archive"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -277,10 +278,8 @@ func buildContainerImage(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("building image: %w", err)
 	}
-	// Reading the response is how we wait for the build to be complete. We don't really care about
-	// the actual response.
-	if _, err := io.ReadAll(buildResponse.Body); err != nil {
-		return fmt.Errorf("reading build response: %w", err)
+	if err := jsonmessage.DisplayJSONMessagesStream(buildResponse.Body, os.Stderr, 0, false, nil); err != nil {
+		return fmt.Errorf("building image: %w", err)
 	}
 	defer buildResponse.Body.Close()
 


### PR DESCRIPTION
## Summary
- The Docker API's `ImageBuild` reports build failures within the response stream, not as an error from the API call itself
- The previous code discarded the stream with `io.ReadAll`, so a broken Containerfile would go undetected if a previously cached image existed
- Replaced with `jsonmessage.DisplayJSONMessagesStream` which parses each JSON message in the stream and returns an error if the build fails

## Test plan
- [x] Introduced a typo in Containerfile (`ubi-minimalXXX`), ran `make test` — tests now fail with a clear error: `building image: invalid reference format`
- [x] Reverted the typo, ran `make test` — all 5 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)