### PR TITLE
chore(deps): update actions/setup-go to v6 and codecov/codecov-action to v6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Go environment
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: acceptance/go.mod
         cache: true
@@ -43,7 +43,7 @@ jobs:
         make test
 
     - name: Upload shell coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         use_oidc: true
         flags: shellspec-tests
@@ -52,7 +52,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload Go coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         use_oidc: true
         flags: acceptance-tests


### PR DESCRIPTION
## Summary
- Update `actions/setup-go` from v5.6.0 to v6.4.0 (SHA-pinned)
- Update `codecov/codecov-action` from v5 to v6.0.1 and pin to commit SHA for supply chain security

Both v6 releases primarily upgrade the Node.js runtime to Node 24. The `codecov/codecov-action` was previously using an unpinned tag (`@v5`), which is now pinned to a commit digest matching the convention used by the other actions in this workflow.

## Test plan
- [ ] CI workflow passes with the updated actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)