### PR TITLE
Fix broken functional test

### DIFF
--- a/.tekton/test.yaml
+++ b/.tekton/test.yaml
@@ -44,7 +44,7 @@ spec:
               echo "=== Test: CA_FILE does not break public registry TLS ==="
 
               # First, verify oras can reach a public registry without CA_FILE
-              if ! oras manifest fetch --no-tty quay.io/podman/hello:latest > /dev/null; then
+              if ! oras manifest fetch quay.io/podman/hello:latest > /dev/null; then
                 echo "SKIP: Cannot reach public registry (no network?)"
               else
                 echo "Baseline: public registry reachable without CA_FILE"
@@ -59,8 +59,7 @@ spec:
                 source /usr/local/bin/oras_opts.sh
 
                 # Same public registry should still be reachable
-                if oras manifest fetch --no-tty \
-                  "${oras_opts[@]}" quay.io/podman/hello:latest > /dev/null; then
+                if oras manifest fetch "${oras_opts[@]}" quay.io/podman/hello:latest > /dev/null; then
                   echo "PASS: Public registry still reachable with CA_FILE set"
                 else
                   echo "FAIL: CA_FILE broke public registry TLS verification"


### PR DESCRIPTION
oras doesn't have the `--no-tty` flag. This was causing the functional tests to be completely skipped.