### PR TITLE
refactor: extract functional test into standalone e2e script

### DIFF
--- a/.tekton/test.yaml
+++ b/.tekton/test.yaml
@@ -15,63 +15,19 @@ spec:
         params:
           - name: SNAPSHOT
         steps:
-          - name: test
-            image: registry.redhat.io/openshift4/ose-cli:latest
+          - name: parse-image
+            image: quay.io/konflux-ci/yq:latest
             env:
               - name: SNAPSHOT
                 value: $(params.SNAPSHOT)
             script: |
               #!/bin/bash
-              set -euo pipefail
-
-              echo -e "Grabbing a copy of yq"
-              oc image extract --confirm quay.io/konflux-ci/yq:latest --path=/usr/bin/yq:/usr/bin/. && chmod +x /usr/bin/yq
-
-              IMAGE=$(echo ${SNAPSHOT} | yq -r '.components[].containerImage')
-              echo "Testing image: ${IMAGE}"
-              TESTS_FAILED="false"
-              failure_num=0
-
-              # Extract scripts and oras from the built image
-              oc image extract --confirm ${IMAGE} \
-                --path=/usr/local/bin/oras:/usr/local/bin/. \
-                --path=/usr/local/bin/oras_opts.sh:/usr/local/bin/. \
-                --path=/usr/local/bin/create-archive:/usr/local/bin/. \
-                --path=/usr/local/bin/use-archive:/usr/local/bin/.
-              chmod +x /usr/local/bin/oras
-
-              ## Test: custom CA_FILE must not break public registry access
-              echo "=== Test: CA_FILE does not break public registry TLS ==="
-
-              # First, verify oras can reach a public registry without CA_FILE
-              if ! oras manifest fetch quay.io/podman/hello:latest > /dev/null; then
-                echo "SKIP: Cannot reach public registry (no network?)"
-              else
-                echo "Baseline: public registry reachable without CA_FILE"
-
-                # Now set CA_FILE to a dummy self-signed cert and source oras_opts.sh
-                openssl req -x509 -newkey ec \
-                  -pkeyopt ec_paramgen_curve:prime256v1 \
-                  -nodes -keyout /tmp/ca.key -out /tmp/ca.crt \
-                  -days 1 -subj "/CN=test-custom-ca" 2>/dev/null
-
-                export CA_FILE=/tmp/ca.crt
-                source /usr/local/bin/oras_opts.sh
-
-                # Same public registry should still be reachable
-                if oras manifest fetch "${oras_opts[@]}" quay.io/podman/hello:latest > /dev/null; then
-                  echo "PASS: Public registry still reachable with CA_FILE set"
-                else
-                  echo "FAIL: CA_FILE broke public registry TLS verification"
-                  TESTS_FAILED="true"
-                  failure_num=$((failure_num + 1))
-                fi
-
-                unset CA_FILE SSL_CERT_FILE
-              fi
-
-              if [ "$TESTS_FAILED" == "true" ]; then
-                echo "$failure_num test(s) failed."
-                exit 1
-              fi
-              echo "All tests passed."
+              echo "${SNAPSHOT}" | yq -r '.components[].containerImage' | tee $(step.results.image.path)
+            results:
+              - name: image
+                type: string
+          - name: test
+            image: $(steps.parse-image.results.image)
+            script: |
+              #!/bin/bash
+              /usr/local/bin/e2e-test

--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,7 @@ COPY use-oci.sh /usr/local/bin/use-archive
 COPY oras_opts.sh /usr/local/bin/oras_opts.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint
 COPY LICENSE /licenses/LICENSE
+COPY test/e2e.sh /usr/local/bin/e2e-test
 
 FROM quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709 AS buildah-task-image
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+TESTS_FAILED="false"
+failure_num=0
+
+## Test: custom CA_FILE must not break public registry access
+echo "=== Test: CA_FILE does not break public registry TLS ==="
+
+if ! oras manifest fetch quay.io/podman/hello:latest > /dev/null; then
+  echo "SKIP: Cannot reach public registry (no network?)"
+else
+  echo "Baseline: public registry reachable without CA_FILE"
+
+  # Dummy self-signed cert unrelated to any real CA
+  cat > /tmp/ca.crt <<'CERT'
+-----BEGIN CERTIFICATE-----
+MIIBhjCCAS2gAwIBAgIUMWB/IxfT7E3bnpquuDJ+0m/yw7cwCgYIKoZIzj0EAwIw
+GTEXMBUGA1UEAwwOdGVzdC1jdXN0b20tY2EwHhcNMjYwNTE5MTUzNjIxWhcNMzYw
+NTE2MTUzNjIxWjAZMRcwFQYDVQQDDA50ZXN0LWN1c3RvbS1jYTBZMBMGByqGSM49
+AgEGCCqGSM49AwEHA0IABE2Il62unn2rdiw72KGrR36mslwxYrs/tvkWbdH/ZT2Q
+E9PY8OYqrl8ZL8hNv40/BFlb3EGEw/nhcLgfHU5JlumjUzBRMB0GA1UdDgQWBBSf
+wwLj7t5SwsY78iVI/EHvmBLV8DAfBgNVHSMEGDAWgBSfwwLj7t5SwsY78iVI/EHv
+mBLV8DAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIBLrf+bx0aPw
+r3Dp2fXufwDiQimEk/4Gkicr/HYuPd+QAiAzAOxAZq89cA/I+yLSdNuaxXmbGXML
+lt9KJxN0MqBcEw==
+-----END CERTIFICATE-----
+CERT
+
+  export CA_FILE=/tmp/ca.crt
+  # shellcheck source=/dev/null
+  source /usr/local/bin/oras_opts.sh
+
+  # Same public registry should still be reachable
+  # shellcheck disable=SC2154 # oras_opts is set by oras_opts.sh
+  if oras manifest fetch "${oras_opts[@]}" quay.io/podman/hello:latest > /dev/null; then
+    echo "PASS: Public registry still reachable with CA_FILE set"
+  else
+    echo "FAIL: CA_FILE broke public registry TLS verification"
+    TESTS_FAILED="true"
+    failure_num=$((failure_num + 1))
+  fi
+
+  unset CA_FILE SSL_CERT_FILE
+fi
+
+if [ "$TESTS_FAILED" == "true" ]; then
+  echo "$failure_num test(s) failed."
+  exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
Move the test logic from the inline Tekton pipeline script into test/e2e.sh so it can be run locally via podman. The pipeline now uses the built image directly as the test step image, eliminating the need for oc image extract and the ose-cli image.