### PR TITLE
Improve ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,27 @@ permissions:
   id-token: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup Go environment
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: acceptance/go.mod
+        cache: true
+        cache-dependency-path: acceptance/go.sum
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      with:
+        working-directory: acceptance
+
+    - name: Run ShellCheck
+      run: shellcheck create-oci.sh use-oci.sh select-oci-auth.sh oras_opts.sh entrypoint.sh hack/demo.sh
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,3 +80,12 @@ jobs:
         files: acceptance/coverage.out
         disable_search: true
         fail_ci_if_error: false
+
+    - name: Upload bash acceptance coverage to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      with:
+        use_oidc: true
+        flags: bash-acceptance-tests
+        files: acceptance/bash-coverage.xml
+        disable_search: true
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 storage
 coverage.out
+bash-coverage.xml

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -3,20 +3,6 @@ kind: Pipeline
 metadata:
   name: build-pipeline
 spec:
-  finally:
-  - name: show-sbom
-    params:
-    - name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
-    taskRef:
-      params:
-      - name: name
-        value: show-sbom
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012
-      - name: kind
-        value: task
-      resolver: bundles
   params:
   - description: Source Repository URL
     name: git-url

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+.PHONY: lint
+lint:
+	@shellcheck create-oci.sh use-oci.sh select-oci-auth.sh oras_opts.sh entrypoint.sh hack/demo.sh
+	@cd acceptance && golangci-lint run ./...
+
 .PHONY: test
 test:
 	@shellspec --shell bash $(shell command -v kcov >/dev/null 2>&1 && echo '--kcov')

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -110,7 +110,7 @@ func setupScenario(ctx context.Context, sc *godog.Scenario) (context.Context, er
 func teardownScenario(ctx context.Context, sc *godog.Scenario, _ error) (context.Context, error) {
 	// Purposely ignore errors here to prevent a teardown error to mask a test error.
 	if registryID, ok := ctx.Value(testRegistryKey).(string); ok {
-		cleanupContainer(ctx, registryID)
+		_ = cleanupContainer(ctx, registryID)
 	}
 
 	ts, _ := getTestState(ctx)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -20,6 +20,21 @@ import (
 
 const mountedPath = "/data"
 
+func TestMain(m *testing.M) {
+	if err := initBashCoverage(); err != nil {
+		fmt.Fprintf(os.Stderr, "bash coverage init: %v\n", err)
+	}
+
+	code := m.Run()
+
+	if err := collectBashCoverage(); err != nil {
+		fmt.Fprintf(os.Stderr, "bash coverage collect: %v\n", err)
+	}
+	cleanupBashCoverage()
+
+	os.Exit(code)
+}
+
 const (
 	testRegistryKey = contextKey("test-registry")
 	caOverrideKey   = contextKey("ca-override")

--- a/acceptance/bash_coverage.go
+++ b/acceptance/bash_coverage.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	bashCoverageDir string
+	repoRoot        string
+)
+
+const (
+	coverageMountPath = "/coverage"
+	coverageInitFile  = "coverage-init.sh"
+	coverageOutput    = "bash-coverage.xml"
+)
+
+var containerToSource = map[string]string{
+	"/usr/local/bin/create-archive":     "create-oci.sh",
+	"/usr/local/bin/use-archive":        "use-oci.sh",
+	"/usr/local/bin/entrypoint":         "entrypoint.sh",
+	"/usr/local/bin/oras_opts.sh":       "oras_opts.sh",
+	"/usr/local/bin/select-oci-auth.sh": "select-oci-auth.sh",
+}
+
+func initBashCoverage() error {
+	root, err := filepath.Abs("..")
+	if err != nil {
+		return fmt.Errorf("resolving repo root: %w", err)
+	}
+	repoRoot = root
+
+	dir, err := os.MkdirTemp("", "ta-bash-coverage-")
+	if err != nil {
+		return fmt.Errorf("creating bash coverage dir: %w", err)
+	}
+
+	initScript := `set -T
+exec 7>>/coverage/trace-$$.log
+trap 'printf "%s:%s\n" "${BASH_SOURCE[0]:-$0}" "${LINENO}" >&7' DEBUG
+`
+
+	if err := os.WriteFile(filepath.Join(dir, coverageInitFile), []byte(initScript), 0644); err != nil {
+		_ = os.RemoveAll(dir)
+		return fmt.Errorf("writing coverage init script: %w", err)
+	}
+
+	bashCoverageDir = dir
+	return nil
+}
+
+func collectBashCoverage() error {
+	if bashCoverageDir == "" {
+		return nil
+	}
+
+	traceFiles, err := filepath.Glob(filepath.Join(bashCoverageDir, "trace-*.log"))
+	if err != nil {
+		return fmt.Errorf("globbing trace files: %w", err)
+	}
+
+	if len(traceFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "bash coverage: no trace files found, skipping report generation")
+		return nil
+	}
+
+	hits := make(map[string]map[int]int)
+	for _, tf := range traceFiles {
+		if err := parseTraceFile(tf, hits); err != nil {
+			fmt.Fprintf(os.Stderr, "bash coverage: skipping %s: %v\n", tf, err)
+		}
+	}
+
+	sourceHits := make(map[string]map[int]int)
+	for containerPath, lines := range hits {
+		sourcePath, ok := containerToSource[containerPath]
+		if !ok {
+			continue
+		}
+		if sourceHits[sourcePath] == nil {
+			sourceHits[sourcePath] = make(map[int]int)
+		}
+		for line, count := range lines {
+			sourceHits[sourcePath][line] += count
+		}
+	}
+
+	for _, sourcePath := range allSourceFiles() {
+		if _, ok := sourceHits[sourcePath]; !ok {
+			sourceHits[sourcePath] = make(map[int]int)
+		}
+	}
+
+	report, err := generateCobertura(sourceHits)
+	if err != nil {
+		return fmt.Errorf("generating cobertura report: %w", err)
+	}
+
+	if err := os.WriteFile(coverageOutput, report, 0644); err != nil {
+		return fmt.Errorf("writing coverage report: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "bash coverage: wrote %s\n", coverageOutput)
+	return nil
+}
+
+func cleanupBashCoverage() {
+	if bashCoverageDir != "" {
+		_ = os.RemoveAll(bashCoverageDir)
+		bashCoverageDir = ""
+	}
+}
+
+func parseTraceFile(path string, hits map[string]map[int]int) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		lastColon := strings.LastIndex(line, ":")
+		if lastColon < 0 {
+			continue
+		}
+
+		filePath := line[:lastColon]
+		lineNum, err := strconv.Atoi(line[lastColon+1:])
+		if err != nil {
+			continue
+		}
+
+		if hits[filePath] == nil {
+			hits[filePath] = make(map[int]int)
+		}
+		hits[filePath][lineNum]++
+	}
+	return scanner.Err()
+}
+
+var nonExecutablePattern = regexp.MustCompile(
+	`^\s*$` +
+		`|^\s*#` +
+		`|^\s*(then|else|fi|do|done|esac|;;)\s*$` +
+		`|^\s*[{}]\s*$` +
+		`|^\s*\)\s*$`,
+)
+
+func isExecutableLine(line string) bool {
+	return !nonExecutablePattern.MatchString(line)
+}
+
+type coberturaReport struct {
+	XMLName  xml.Name          `xml:"coverage"`
+	LineRate string            `xml:"line-rate,attr"`
+	Version  string            `xml:"version,attr"`
+	Sources  coberturaSources  `xml:"sources"`
+	Packages coberturaPackages `xml:"packages"`
+}
+
+type coberturaSources struct {
+	Source []string `xml:"source"`
+}
+
+type coberturaPackages struct {
+	Package []coberturaPackage `xml:"package"`
+}
+
+type coberturaPackage struct {
+	Name     string           `xml:"name,attr"`
+	LineRate string           `xml:"line-rate,attr"`
+	Classes  coberturaClasses `xml:"classes"`
+}
+
+type coberturaClasses struct {
+	Class []coberturaClass `xml:"class"`
+}
+
+type coberturaClass struct {
+	Name     string         `xml:"name,attr"`
+	Filename string         `xml:"filename,attr"`
+	LineRate string         `xml:"line-rate,attr"`
+	Lines    coberturaLines `xml:"lines"`
+}
+
+type coberturaLines struct {
+	Line []coberturaLine `xml:"line"`
+}
+
+type coberturaLine struct {
+	Number int `xml:"number,attr"`
+	Hits   int `xml:"hits,attr"`
+}
+
+func generateCobertura(sourceHits map[string]map[int]int) ([]byte, error) {
+	var totalLines, totalHit int
+	var classes []coberturaClass
+
+	sourceFiles := make([]string, 0, len(sourceHits))
+	for sf := range sourceHits {
+		sourceFiles = append(sourceFiles, sf)
+	}
+	sort.Strings(sourceFiles)
+
+	for _, sourcePath := range sourceFiles {
+		hitMap := sourceHits[sourcePath]
+
+		content, err := os.ReadFile(filepath.Join(repoRoot, sourcePath))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bash coverage: cannot read source %s: %v\n", sourcePath, err)
+			continue
+		}
+
+		lines := strings.Split(string(content), "\n")
+		var classLines []coberturaLine
+		var fileTotal, fileHit int
+
+		for i, lineText := range lines {
+			lineNum := i + 1
+			if !isExecutableLine(lineText) {
+				continue
+			}
+			fileTotal++
+			hits := hitMap[lineNum]
+			if hits > 0 {
+				fileHit++
+			}
+			classLines = append(classLines, coberturaLine{
+				Number: lineNum,
+				Hits:   hits,
+			})
+		}
+
+		totalLines += fileTotal
+		totalHit += fileHit
+
+		lineRate := "0"
+		if fileTotal > 0 {
+			lineRate = fmt.Sprintf("%.4f", float64(fileHit)/float64(fileTotal))
+		}
+
+		classes = append(classes, coberturaClass{
+			Name:     sourcePath,
+			Filename: sourcePath,
+			LineRate: lineRate,
+			Lines:    coberturaLines{Line: classLines},
+		})
+	}
+
+	overallRate := "0"
+	if totalLines > 0 {
+		overallRate = fmt.Sprintf("%.4f", float64(totalHit)/float64(totalLines))
+	}
+
+	report := coberturaReport{
+		LineRate: overallRate,
+		Version:  "1.0",
+		Sources:  coberturaSources{Source: []string{"."}},
+		Packages: coberturaPackages{
+			Package: []coberturaPackage{
+				{
+					Name:     "bash-scripts",
+					LineRate: overallRate,
+					Classes:  coberturaClasses{Class: classes},
+				},
+			},
+		},
+	}
+
+	output, err := xml.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte(xml.Header), output...), nil
+}
+
+func allSourceFiles() []string {
+	files := make([]string, 0, len(containerToSource))
+	for _, sf := range containerToSource {
+		files = append(files, sf)
+	}
+	sort.Strings(files)
+	return files
+}

--- a/acceptance/certs.go
+++ b/acceptance/certs.go
@@ -54,7 +54,7 @@ func generateSelfSignedCert(cert, key string) error {
 	if err != nil {
 		return err
 	}
-	defer certOut.Close()
+	defer func() { _ = certOut.Close() }()
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}); err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func generateSelfSignedCert(cert, key string) error {
 	if err != nil {
 		return err
 	}
-	defer keyOut.Close()
+	defer func() { _ = keyOut.Close() }()
 	privBytes, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
 		return err

--- a/acceptance/container.go
+++ b/acceptance/container.go
@@ -179,6 +179,11 @@ func runContainer(ctx context.Context, cmd, binds []string, cert string) (contex
 	}
 	env = append(env, fmt.Sprintf("CA_FILE=%s", cert))
 
+	if bashCoverageDir != "" {
+		binds = append(binds, fmt.Sprintf("%s:%s:Z", bashCoverageDir, coverageMountPath))
+		env = append(env, fmt.Sprintf("BASH_ENV=%s/%s", coverageMountPath, coverageInitFile))
+	}
+
 	user, err := user.Current()
 	if err != nil {
 		return ctx, err

--- a/acceptance/container.go
+++ b/acceptance/container.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -81,8 +81,8 @@ func runRegistry(ctx context.Context, binds []string, certs, key string) (string
 		if err != nil {
 			panic(err)
 		}
-		defer reader.Close()
-		io.Copy(os.Stdout, reader)
+		defer func() { _ = reader.Close() }()
+		_, _ = io.Copy(os.Stdout, reader)
 	}
 
 	cont, err := containerClient.ContainerCreate(
@@ -158,7 +158,7 @@ func cleanupContainer(ctx context.Context, containerID string) error {
 		return fmt.Errorf("inspecting container: %w", err)
 	}
 
-	stopContainer(ctx, containerID)
+	_ = stopContainer(ctx, containerID)
 
 	hostBinds := containerJSON.HostConfig.Binds
 	// Remove bind mounts
@@ -205,7 +205,7 @@ func runContainer(ctx context.Context, cmd, binds []string, cert string) (contex
 		return ctx, fmt.Errorf("creating container: %w", err)
 	}
 
-	defer containerClient.ContainerRemove(ctx, cont.ID, container.RemoveOptions{Force: true})
+	defer func() { _ = containerClient.ContainerRemove(ctx, cont.ID, container.RemoveOptions{Force: true}) }()
 
 	if err := containerClient.ContainerStart(ctx, cont.ID, container.StartOptions{}); err != nil {
 		return ctx, fmt.Errorf("starting container %s: %w", cont.ID, err)
@@ -258,7 +258,7 @@ func getContainerLogs(ctx context.Context, contID string) string {
 
 func buildContainerImage(ctx context.Context) error {
 	targetArch := runtime.GOARCH
-	opts := types.ImageBuildOptions{
+	opts := build.ImageBuildOptions{
 		Dockerfile: "Containerfile",
 		Tags:       []string{containerImage},
 		BuildArgs: map[string]*string{
@@ -281,7 +281,7 @@ func buildContainerImage(ctx context.Context) error {
 	if err := jsonmessage.DisplayJSONMessagesStream(buildResponse.Body, os.Stderr, 0, false, nil); err != nil {
 		return fmt.Errorf("building image: %w", err)
 	}
-	defer buildResponse.Body.Close()
+	defer func() { _ = buildResponse.Body.Close() }()
 
 	return nil
 }

--- a/create-oci.sh
+++ b/create-oci.sh
@@ -22,7 +22,7 @@ set -o pipefail
 # using `-n` ensures gzip does not add a modification time to the output. This
 # helps in ensuring the archive digest is the same for the same content.
 tar_opts=(--create --use-compress-program='gzip -n' --file)
-if [[ ! -z "${DEBUG:-}" ]]; then
+if [[ -n "${DEBUG:-}" ]]; then
   tar_opts=(--verbose "${tar_opts[@]}")
   set -o xtrace
 fi
@@ -57,7 +57,7 @@ archive_dir="$(mktemp -d)"
 
 artifacts=()
 
-repo="$(echo -n $store | sed 's_/\(.*\):\(.*\)_/\1_g')"
+repo="$(echo -n "$store" | sed 's_/\(.*\):\(.*\)_/\1_g')"
 
 tmp_workdir=$(mktemp -d --tmpdir create-oci.sh.XXXXXX)
 trap 'rm -rf $tmp_workdir' EXIT
@@ -71,7 +71,7 @@ for artifact_pair in "${artifact_pairs[@]}"; do
       continue
     fi
 
-    artifact_name="$(basename ${result_path})"
+    artifact_name="$(basename "${result_path}")"
 
     archive="${archive_dir}/${artifact_name}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ log() {
     :
 }
 
-if [[ ! -z "${DEBUG:-}" ]]; then
+if [[ -n "${DEBUG:-}" ]]; then
     log() {
         # shellcheck disable=SC2059
         printf "DEBUG: %s\n" "$(printf "${@}")"

--- a/oras_opts.sh
+++ b/oras_opts.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-oras_opts=(${ORAS_OPTIONS:-})
+oras_opts=()
+if [[ -n "${ORAS_OPTIONS:-}" ]]; then
+    IFS=' ' read -ra oras_opts <<< "$ORAS_OPTIONS"
+fi
 
 # When a custom CA file is provided, set SSL_CERT_FILE to point to it.
 # SSL_CERT_FILE is respected by Go's crypto/x509 (used by oras) and is ADDITIVE,
@@ -19,6 +22,6 @@ if [[ -v CA_FILE && -n "$CA_FILE" ]]; then
     fi
 fi
 
-if [[ ! -z "${DEBUG:-}" ]]; then
+if [[ -n "${DEBUG:-}" ]]; then
     oras_opts+=(--debug)
 fi

--- a/select-oci-auth.sh
+++ b/select-oci-auth.sh
@@ -30,7 +30,7 @@ original_ref="$1"
 ref="${original_ref/@*}"
 
 # Remove tag from image reference while making sure optional registry port is taken into account
-ref="$(echo -n $ref | sed 's_/\(.*\):\(.*\)_/\1_g')"
+ref="$(echo -n "$ref" | sed 's_/\(.*\):\(.*\)_/\1_g')"
 
 registry="${ref/\/*}"
 
@@ -38,10 +38,10 @@ AUTHFILE="${AUTHFILE:-$HOME/.docker/config.json}"
 
 if [[ -f $AUTHFILE ]]; then
     while true; do
-        token=$(< "${AUTHFILE}" jq -c '.auths["'$ref'"]')
+        token=$(< "${AUTHFILE}" jq -c '.auths["'"$ref"'"]')
         if [[ "$token" != "null" && "$token" != "" ]]; then
             >&2 echo "Using token for $ref"
-            echo -n '{"auths": {"'$registry'": '$token'}}' | jq -c .
+            echo -n '{"auths": {"'"$registry"'": '"$token"'}}' | jq -c .
             exit 0
         fi
 

--- a/use-oci.sh
+++ b/use-oci.sh
@@ -14,7 +14,7 @@ set -o nounset
 set -o pipefail
 
 tar_opts=-zxpf
-if [[ ! -z "${DEBUG:-}" ]]; then
+if [[ -n "${DEBUG:-}" ]]; then
   tar_opts=-zxvpf
   set -o xtrace
 fi


### PR DESCRIPTION
## Summary

- **Add shellcheck and golangci-lint linting** — New `make lint` target and GitHub Actions lint job. Fixes all issues found by both linters across shell scripts and Go acceptance tests.
- **Collect bash script coverage from acceptance tests** — Uses bash's `DEBUG` trap via `BASH_ENV` to trace executed lines inside test containers. A dynamically generated `coverage-init.sh` is bind-mounted into each container, and trace files are parsed into Cobertura XML for Codecov. Scripts like `create-oci.sh` and `use-oci.sh` previously showed 0% coverage despite being exercised by acceptance tests.
- **Remove show-sbom Tekton Task** — Unused task that consumed resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)