### PR TITLE
Add .codecov.yml configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true


### PR DESCRIPTION
## Summary

- Adds `.codecov.yml` with standard Konflux coverage settings
- Project coverage target: auto (threshold: 1%)
- Patch coverage target: 80%
- All checks are **informational** — coverage results are reported but never block CI

## Details

| Setting | Value |
|---------|-------|
| `require_ci_to_pass` | `false` |
| Project target | `auto` (tracks current coverage) |
| Project threshold | `1%` (allowed drop) |
| Patch target | `80%` (new lines) |
| `informational` | `true` (never blocks PRs) |
| `require_changes` | `true` (only comments when coverage changes) |

## Reference

Part of org-wide codecov rollout ([KFLUXDP-1020](https://issues.redhat.com/browse/KFLUXDP-1020))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ