### PR TITLE
use-oci: fix retry usage for blob fetch

### DIFF
--- a/use-oci.sh
+++ b/use-oci.sh
@@ -79,8 +79,14 @@ for artifact_pair in "${artifact_pairs[@]}"; do
     authfile=$(mktemp --tmpdir="$tmp_workdir" "auth-XXXXXX.json")
     select-oci-auth.sh "$name" > "$authfile"
 
-    retry oras blob fetch "${oras_opts[@]}" --registry-config "$authfile" \
-        "${name}" --output - | tar -C "${destination}" "${tar_opts}" -
+    oras_cmd=$(
+        printf '%q ' oras blob fetch "${oras_opts[@]}" --registry-config "$authfile" \
+            "${name}" --output -
+    )
+    tar_cmd=$(
+        printf '%q ' tar -C "${destination}" "${tar_opts}" -
+    )
+    retry /bin/bash -o pipefail -c "${oras_cmd} | ${tar_cmd}"
 
     echo "Restored artifact ${name} to ${destination}"
 done


### PR DESCRIPTION
KONFLUX-15042

Previously, the script was piping the output of 'retry oras blob fetch' to 'tar -xzf'.

If the oras process failed after having already written some data to stdout (e.g. due to intermittent network errors), the tar process would almost certainly fail as well due to corrupted (incomplete) input.

The retry script would then start the oras fetch again, but the stdout of the whole retry process would still be connected to the stdin of a tar process that has already exited. So all the retry attempts would be guaranteed to fail on attempting to write to a broken pipe.

Fix by retrying the whole "oras fetch -> untar" pipeline instead of retrying only its fetch side. If tar has already written some files from a previous attempt, it will overwrite them on the next one, making it functionally idempotent.

Another option would be to write the output of oras blob fetch to a file instead of piping it to tar, but that would result in up to double the disk IO for the happy path.