### PR TITLE
fix(ci): run brew update before installing test dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,7 @@ jobs:
       # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#homebrew-note
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        brew update
         brew tap shellspec/shellspec
         brew install shellspec kcov
 


### PR DESCRIPTION
## Summary
- Add `brew update` before `brew install` in the test workflow to fix CI failures caused by a stale Homebrew cache on GitHub Actions runners.
- The cached Homebrew version crashes with `unknown install step: run` when installing newer bottle formats (seen in [PR #394 CI](https://github.com/konflux-ci/build-trusted-artifacts/actions/runs/31242970270/job/93066849553?pr=394)).

## Test plan
- [ ] Verify the `test` job passes on this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)