### PR TITLE
fix: support rootless podman in acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,35 @@ podman run -v $(pwd):/export/run -v ~/.docker/config.json:/home/notroot/.docker/
 podman run -v ~/.docker/config.json:/home/notroot/.docker/config.json:ro -it quay.io/jstuart/build-trusted-artifacts use "$(cat result)=/var/tmp"
 ```
 
+## Running the acceptance tests
+
+A container runtime is required to run the acceptance tests. Either
+[Docker](https://docs.docker.com/engine/install/) or
+[Podman](https://podman.io/docs/installation) can be used.
+
+Run the tests with:
+
+```shell
+make test
+```
+
+### Podman rootless setup
+
+When using Podman in rootless mode, enable the Podman socket and set the
+`DOCKER_HOST` environment variable so the Docker client library can communicate
+with Podman:
+
+```shell
+systemctl --user enable --now podman.socket
+export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
+```
+
+To persist `DOCKER_HOST` across sessions, add the export to your shell profile:
+
+```shell
+echo 'export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock' >> ~/.bash_profile
+```
+
 ## Options
 
 * Set `AUTHFILE` to point to an alternative location for `$HOME/.docker/config.json`.

--- a/acceptance/container.go
+++ b/acceptance/container.go
@@ -25,6 +25,7 @@ import (
 )
 
 var containerClient *client.Client
+var usePodmanUserns bool
 
 type contextKey string
 
@@ -46,6 +47,24 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("creating new client: %s", err))
 	}
+
+	ctx := context.Background()
+	version, err := containerClient.ServerVersion(ctx)
+	if err == nil {
+		for _, component := range version.Components {
+			if strings.Contains(strings.ToLower(component.Name), "podman") {
+				usePodmanUserns = true
+				break
+			}
+		}
+	}
+}
+
+func usernsMode() container.UsernsMode {
+	if usePodmanUserns {
+		return "keep-id"
+	}
+	return ""
 }
 
 func runRegistry(ctx context.Context, binds []string, certs, key string) (string, error) {
@@ -105,6 +124,7 @@ func runRegistry(ctx context.Context, binds []string, certs, key string) (string
 			NetworkMode:  container.NetworkMode(networkName),
 			SecurityOpt:  []string{"label:disable"},
 			Privileged:   true,
+			UsernsMode:   usernsMode(),
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{},
@@ -201,6 +221,7 @@ func runContainer(ctx context.Context, cmd, binds []string, cert string) (contex
 		&container.HostConfig{
 			Binds:       binds,
 			NetworkMode: container.NetworkMode(networkName),
+			UsernsMode:  usernsMode(),
 		},
 		&network.NetworkingConfig{},
 		&ocispec.Platform{},


### PR DESCRIPTION
## Summary
- Detect podman via the `ServerVersion` API and set `UsernsMode` to `keep-id` on container creation, preserving host UID mapping. Without this, rootless podman's user namespace remapping causes permission denied errors when containers access bind-mounted files.
- Add README section documenting how to run acceptance tests with Docker or Podman, including rootless podman socket setup.

## Test plan
- [x] `go test ./...` passes under rootless podman
- [ ] Verify acceptance tests still pass under Docker (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)